### PR TITLE
Prefer variable declaration and assignment adjacent to usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,27 +406,13 @@
     var i;
     ```
 
-  - Assign variables at the top of their scope. This helps avoid issues with variable declaration and assignment hoisting related issues.
+  - Variables should be declared and assigned adjacent to their usage to maximize code comprehension and readability.
+
+    (Some style guides advocate declaration and assignment be moved to the top of the scope to help avoid issues related to variable hoisting. Our guideline is to prefer code comprehension and readability over avoidance of relatively rare hoisting issues.)
 
     ```javascript
     // bad
     function() {
-      test();
-      console.log('doing stuff..');
-
-      //..other stuff..
-
-      var name = getName();
-
-      if (name === 'test') {
-        return false;
-      }
-
-      return name;
-    }
-
-    // good
-    function() {
       var name = getName();
 
       test();
@@ -441,26 +427,19 @@
       return name;
     }
 
-    // bad
-    function() {
-      var name = getName();
-
-      if (!arguments.length) {
-        return false;
-      }
-
-      return true;
-    }
-
     // good
     function() {
-      if (!arguments.length) {
+      test();
+      console.log('doing stuff..');
+
+      //..other stuff..
+
+      var name = getName();
+      if (name === 'test') {
         return false;
       }
 
-      var name = getName();
-
-      return true;
+      return name;
     }
     ```
 


### PR DESCRIPTION
This pull changes our style guide to prefer a variable declaration close to its usage. 

Code is often less comprehensible when you have to go hunting for declarations, and a big block of declarations at the beginning of a method just isn't very useful. The reason for the "top of scope" guideline is due to the variable "hoisting" performed by javascript, but I don't think I've ever once run into an error the was a result of a hoisting "gotcha", and so it doesn't make much sense to me to make the code less comprehensible for it.