### PR TITLE
Fix code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,7 +677,7 @@
 
       return this;
     }
-  ```
+    ```
 
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Fixed the formatting so the lower half of the readme wouldn't show as *all* code. Some misplaced backticks caused the issue.